### PR TITLE
[.editorconfig] Add new rules for json and yaml and update indentations rule

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,9 +14,5 @@ charset=utf-8
 trim_trailing_whitespace = false
 max_line_length = 0
 
-[{*.json,*.yml}]
-indent_size = 2
-indent_style = space
-
 [COMMIT_EDITMSG]
 max_line_length = 0

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,22 @@
+
+# DOCS: http://editorconfig.org
 root=true
+
 [*]
 indent_style=space
-indent_size=4
+indent_size=2
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 charset=utf-8
+
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = 0
+
+[{*.json,*.yml}]
+indent_size = 2
+indent_style = space
+
+[COMMIT_EDITMSG]
+max_line_length = 0


### PR DESCRIPTION
### Update some rules
* indent_size to `2` when before `4`  because it will eat a lot of places

### Add rules for
* trim_trailing_whitespace to `true` for remove whitespace on new line in all extensions except markdown
* charset to `utf 8`
*  [COMMIT_EDITMSG] set `max_line_length` Forces hard line wrapping after the amount of characters specified its only effected (Emacs, Vim, Atom, ReSharper and Rider, AppCode, IntelliJ, IDEA, PhpStorm, PyCharm, RubyMine, and WebStorm
Kakoune)
